### PR TITLE
Add clickable link to Telegram comunity page

### DIFF
--- a/docs/source/qr.rst
+++ b/docs/source/qr.rst
@@ -1,7 +1,9 @@
 Telegram Group
 ==============
 
-Scan this QR code to join our Telegram group:
+Scan this QR code or `click this link`_ to join our Telegram group:
 
 .. image:: ./_static/img/qr.jpg
     :alt: QR code for telegram group
+
+.. _`click this link`: https://t.me/python_belgrade


### PR DESCRIPTION
Sometimes all the user have is a mobile phone, and a mobile phone can't scan the QR code on its own screen)