### PR TITLE
Fix StrEnum f-string formatting for Python < 3.12

### DIFF
--- a/docs/source/meetups/meetup_10.rst
+++ b/docs/source/meetups/meetup_10.rst
@@ -16,7 +16,8 @@ Horetu presentation
   ../speakers/speaker_18
 
 - Abstract:
-Horetu exposes ordinary Python functions as other user interfaces. When applied to a function, it automatically constructs corresponding command-line interfaces, web interfaces, configuration files, internet relay chat (IRC) bots, and Django management commands. It is a great way to set up quickly a user interface for a Python program.References:
+Horetu exposes ordinary Python functions as other user interfaces. When applied to a function, it automatically constructs corresponding command-line interfaces, web interfaces, configuration files, internet relay chat (IRC) bots, and Django management commands. It is a great way to set up quickly a user interface for a Python program.
+References:
 - `Horetu <https://pypi.python.org/pypi/horetu/>`_
 
 Python applications in production

--- a/docs/source/meetups/meetup_12.rst
+++ b/docs/source/meetups/meetup_12.rst
@@ -16,7 +16,8 @@ Serverless technologies
   ../speakers/speaker_15
 
 - Abstract:
-Mislav Cimpersak will talk about Serverless technologies. He will present both positive and negative sides of Serverless technologies and he will also talk about the ways of applying Python on them. Mislav will provide us with code examples for better understanding and he will demonstrate how we can make great use of it.References:
+Mislav Cimpersak will talk about Serverless technologies. He will present both positive and negative sides of Serverless technologies and he will also talk about the ways of applying Python on them. Mislav will provide us with code examples for better understanding and he will demonstrate how we can make great use of it.
+References:
 - `Styria <https://www.styria.com/en/>`_
 
 Transferring Mobile Games to the Cloud with Python

--- a/docs/source/meetups/meetup_14.rst
+++ b/docs/source/meetups/meetup_14.rst
@@ -16,7 +16,8 @@ Talk about his experience considering game programming
   ../speakers/speaker_52
 
 - Abstract:
-He will talk about his experience considering game programming, Switchcars and of course about the Derail Valley (http://www.derailvalley.com/), his new project that has already won a prize on a worldwide MSI VR Jam contest.References:
+He will talk about his experience considering game programming, Switchcars and of course about the Derail Valley (http://www.derailvalley.com/), his new project that has already won a prize on a worldwide MSI VR Jam contest.
+References:
 - `Altfuture <http://altfuture.tumblr.com/about>`_
 - `Switchcars <http://switchcarsgame.com/>`_
 - `Derail Valley <(http://www.derailvalley.com/>`_
@@ -28,7 +29,8 @@ Developing games in a Ren'Py surrounding, that is based on Python
   ../speakers/speaker_50
 
 - Abstract:
-talk about developing games in a Ren'Py surrounding, that is based on Python. It is also known as a "visual novel engine" and this will be a great opportunity for everyone that are interested in the development of visual novels (such as Japanese iconography) to hear something about the tools of gamedev technologies.References:
+talk about developing games in a Ren'Py surrounding, that is based on Python. It is also known as a "visual novel engine" and this will be a great opportunity for everyone that are interested in the development of visual novels (such as Japanese iconography) to hear something about the tools of gamedev technologies.
+References:
 - `Ren'Py <http://www.renpy.org/>`_
 - `Visual Novel <http://en.wikipedia.org/wiki/Visual_novel>`_
 

--- a/docs/source/meetups/meetup_2.rst
+++ b/docs/source/meetups/meetup_2.rst
@@ -16,7 +16,8 @@ asyncio
   ../speakers/speaker_27
 
 - Abstract:
-Milan will talk about the shiny new asynchronous event loop module, introduced in Python 3.4, set to tackle various implementations and bring them all under one roof and into the standard library.References:
+Milan will talk about the shiny new asynchronous event loop module, introduced in Python 3.4, set to tackle various implementations and bring them all under one roof and into the standard library.
+References:
 - `asyncio <https://docs.python.org/3/library/asyncio.html>`_
 
 Convert your Python script into executable Windows programs, able to run without requiring a Python installation.
@@ -26,7 +27,8 @@ Convert your Python script into executable Windows programs, able to run without
   ../speakers/speaker_20
 
 - Abstract:
-Zeljko will be giving a hands-on presentation of how you can package, deploy and execute your Python scripts all nicely packed-up in a Windows-executable binary file. He will also offer us some pros and cons as to when and why we should use this little handy toolkit.References:
+Zeljko will be giving a hands-on presentation of how you can package, deploy and execute your Python scripts all nicely packed-up in a Windows-executable binary file. He will also offer us some pros and cons as to when and why we should use this little handy toolkit.
+References:
 - `py2exe <http://www.py2exe.org/>`_
 
 A Python SQL toolkit and Object Relational Mapper that gives application developers the full power and flexibility of SQL.
@@ -36,7 +38,8 @@ A Python SQL toolkit and Object Relational Mapper that gives application develop
   ../speakers/speaker_31
 
 - Abstract:
-Bojan will provide us with insights into how to wrap up your applications to use Python’s popular ORM library to release some tension and not worry about databases and complex queries.References:
+Bojan will provide us with insights into how to wrap up your applications to use Python’s popular ORM library to release some tension and not worry about databases and complex queries.
+References:
 - `SQLAlchemy <http://www.sqlalchemy.org/>`_
 
 How I made a programming language in Serbian/Cyrilic in three days

--- a/docs/source/meetups/meetup_24.rst
+++ b/docs/source/meetups/meetup_24.rst
@@ -25,6 +25,7 @@ Procedural generation in Python
   ../speakers/speaker_35
 
 - Abstract:
-A short introduction to the basics of procedural generation, followed by a demonstration of how to generate terrain using noise functions and how to generate fractal art in python.References:
+A short introduction to the basics of procedural generation, followed by a demonstration of how to generate terrain using noise functions and how to generate fractal art in python.
+References:
 - `WorldEngine - a world generator <https://github.com/Mindwerks/worldengine>`_
 

--- a/docs/source/meetups/meetup_25.rst
+++ b/docs/source/meetups/meetup_25.rst
@@ -30,7 +30,8 @@ Narrenschiff: More than a satire, a tool!
 - Abstract:
 Do you need to encrypt Kubernetes secrets and safely commit manifests and custom Helm charts? Do you need to rebuild a cluster, or to have another copy of an existing namespace - but you don't remember how you did it in the first place? Narrenschiff is a Kubernetes configuration management tool for small business.
 
-It's also a story of a DevOps engineer's frustration with tool fatigue - and then taking it a step further.References:
+It's also a story of a DevOps engineer's frustration with tool fatigue - and then taking it a step further.
+References:
 - `NarrenOrg <https://github.com/narrenorg>`_
 - `Narrenschiff <https://narrenschiff.xyz>`_
 

--- a/docs/source/meetups/meetup_3.rst
+++ b/docs/source/meetups/meetup_3.rst
@@ -13,10 +13,11 @@ Kratka uvodna prica o iPythonu
 ---
 
 .. toctree::
-
+  ../speakers/speaker_65
 
 - Abstract:
-U periodu od 15 minuta, Stefan ce pokrenuti Jupyter Notebook-a i, kroz poredjenje obicnog Python interaktivnog shell-a sa Jupyter-ovim, pokusace da nagovesti prednosti i mane ove web aplikacije.References:
+U periodu od 15 minuta, Stefan ce pokrenuti Jupyter Notebook-a i, kroz poredjenje obicnog Python interaktivnog shell-a sa Jupyter-ovim, pokusace da nagovesti prednosti i mane ove web aplikacije.
+References:
 - `JuPyter <http://jupyter.org/>`_
 
 Spark Python API
@@ -28,7 +29,8 @@ Spark Python API
 - Abstract:
 PySpark nudi Python-u pristup Spark-ovom programming modelu, i pomaze da se na brz i efikasan nacin isprocesuiraju velike kolicine podataka.
 
-Milos ce nam za kratak vremenski period pruziti uvid u jedan od najpopularnijih data alata i data tehnologija prosle godine. Procice kroz neke od core API funkcionalnosti i iznece pozitivne i negativne strane koriscenja PySpark aplikacije za resavanje problema skladistenja masivnih kolicina podataka.References:
+Milos ce nam za kratak vremenski period pruziti uvid u jedan od najpopularnijih data alata i data tehnologija prosle godine. Procice kroz neke od core API funkcionalnosti i iznece pozitivne i negativne strane koriscenja PySpark aplikacije za resavanje problema skladistenja masivnih kolicina podataka.
+References:
 - `Spark <https://spark.apache.org/>`_
 
 Manipulacija podataka sa Pandas bibliotekom
@@ -40,6 +42,7 @@ Manipulacija podataka sa Pandas bibliotekom
 - Abstract:
 Zarko ce u periodu od 15 minuta probati da nam kroz live coding sesiju na konkretnom data setu prikaže kako može izgledati analiza podataka pomoću Pandas biblioteke.
 
-Biće demonstriran delić mogućnosti biblioteke kako bi vam zagolicali mastu i skrenuli paznju na velike mogucnosti Python-a za manipulaciju raznih tipova datasetova.References:
+Biće demonstriran delić mogućnosti biblioteke kako bi vam zagolicali mastu i skrenuli paznju na velike mogucnosti Python-a za manipulaciju raznih tipova datasetova.
+References:
 - `Pandas <https://pandas.pydata.org/>`_
 

--- a/docs/source/meetups/meetup_30.rst
+++ b/docs/source/meetups/meetup_30.rst
@@ -20,7 +20,8 @@ Black-box testing with Kiwi TCMS
 - Quick info about the black box hardware
 - Share with the audience why these black boxes exist and what kinds of biases they serve to demonstrate.
 
-The talk will be mostly be around hardware Kiwi TCMS boxes, Alexander will be bringing a couple of them so that the attendees will be able to play around with them throughout the event.References:
+The talk will be mostly be around hardware Kiwi TCMS boxes, Alexander will be bringing a couple of them so that the attendees will be able to play around with them throughout the event.
+References:
 - `Hardware for teaching exploratory testing <https://github.com/kiwitcms/black-boxes>`_
 - `Progress update on open source hardware for black-box testing in cooperation with Pionir <https://kiwitcms.org/blog/kiwi-tcms-team/2020/10/10/progress-update-on-open-source-hardware-for-black-box-testing/>`_
 

--- a/docs/source/meetups/meetup_4.rst
+++ b/docs/source/meetups/meetup_4.rst
@@ -34,7 +34,8 @@ BigML
   ../speakers/speaker_62
 
 - Abstract:
-BigML makes machine learning easy by taking care of the details required to add data-driven decisions and predictive power to your company. Ondrej will give us a crash course on how to get us quickly up and running with this cloud machine learning platform.References:
+BigML makes machine learning easy by taking care of the details required to add data-driven decisions and predictive power to your company. Ondrej will give us a crash course on how to get us quickly up and running with this cloud machine learning platform.
+References:
 - `BigML <bigml.com>`_
 
 Python OCR

--- a/docs/source/meetups/meetup_8.rst
+++ b/docs/source/meetups/meetup_8.rst
@@ -25,7 +25,7 @@ challenges of distributed systems
 
 
 
-
+No title
 ---
 
 .. toctree::

--- a/docs/source/speakers/speaker_65.rst
+++ b/docs/source/speakers/speaker_65.rst
@@ -1,0 +1,21 @@
+Nikolai Sviridov
+=================
+Developer Advocate at ITism
+
+
+
+- :icon:`fa-brands fa-linkedin-in` `linkedin <https://linkedin.com/in/luchanos>`_
+
+- https://github.com/luchanos
+
+
+.. image:: ../_static/img/speakers/nikolai-sviridov.jpg
+    :alt: profile-photo
+    :width: 200px
+
+
+
+Talks on meetups:
+
+- :ref:`meetup_3`
+

--- a/docs/source/speakers/speaker_66.rst
+++ b/docs/source/speakers/speaker_66.rst
@@ -3,7 +3,9 @@ Snežana Jovičić
 PhD Researcher in Genetics
 
 
+
 - :icon:`fa-brands fa-linkedin-in` `linkedin <https://www.linkedin.com/in/snežana-jovičić-molecules>`_
+
 
 Talks on meetups:
 

--- a/docs/source/speakers/speaker_67.rst
+++ b/docs/source/speakers/speaker_67.rst
@@ -3,7 +3,9 @@ Strahinja Stevanović
 PhD, Persida Inc.
 
 
+
 - :icon:`fa-brands fa-linkedin-in` `linkedin <https://www.linkedin.com/in/strahinjastevanovic>`_
+
 
 Talks on meetups:
 

--- a/src/loading.py
+++ b/src/loading.py
@@ -5,7 +5,7 @@ from src.const import JSON_DATA_DIR, JSONType, MeetupData, SpeakerData
 
 
 def get_json_objects(type_: JSONType, *ids) -> List:
-    with open(f"{JSON_DATA_DIR}/{type_}.json", "r") as file:
+    with open(f"{JSON_DATA_DIR}/{type_.value}.json", "r") as file:
         data = json.load(file)
 
     if len(ids) == 0:


### PR DESCRIPTION
## Summary

- `get_json_objects` in `src/loading.py` built the file path using `f"{type_}.json"`, where `type_` is a `JSONType` enum instance
- In Python < 3.12, f-string formatting of a `str`-subclass enum calls `Enum.__format__`, returning `"JSONType.MEETUPS"` instead of `"meetups"`, causing a `FileNotFoundError`
- Fixed by using `type_.value` explicitly, which works correctly across all supported versions (`^3.8`)

## Test plan

- [ ] Run `python3 generate_rst.py` and confirm it completes without error
- [ ] Verify RST files are generated in `docs/source/meetups/` and `docs/source/speakers/`

https://claude.ai/code/session_011irM84LoygHZ7MFvTCxsC2