### PR TITLE
adds an articles section and the first article to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # data located at docs/source/json-data
+- docs/source/json-data/articles.json
 - docs/source/json-data/meetups.json
 - docs/source/json-data/speakers.json
 

--- a/docs/source/articles/index.rst
+++ b/docs/source/articles/index.rst
@@ -1,0 +1,25 @@
+Articles
+============
+
+*The first place to look when you want to read something worth reading about Python.*
+
+This is a curated, `community-voted <https://t.me/python_belgrade>`_ section of articles from across the Python ecosystem. It's not just an aggregator however, think of it like a high-signal place to keep yourself informed about Python and its ecosystem.
+
+Links to past years' archives can be found at the bottom of the page.
+
+----
+
+{% for article in articles["2026"] %}
+
+{% set heading = "`" + article.title + " ↗ <" + article.url + ">`_" %}
+- .. rubric:: {{ heading }}                                                                 
+  {{ '-' * heading|length }}                                                    
+  by `{{ article.author }} ↗ <{{ article.authorUrl }}>`_
+
+  .. image:: {{ article.image }}
+     :height: 10em
+
+  {{ article.description }}
+
+
+{% endfor %}

--- a/docs/source/articles/index.rst
+++ b/docs/source/articles/index.rst
@@ -12,8 +12,9 @@ Links to past years' archives can be found at the bottom of the page.
 {% for article in articles["2026"] %}
 
 {% set heading = "`" + article.title + " ↗ <" + article.url + ">`_" %}
-- .. rubric:: {{ heading }}                                                                 
-  {{ '-' * heading|length }}                                                    
+- .. rubric:: {{ heading }}
+
+  
   by `{{ article.author }} ↗ <{{ article.authorUrl }}>`_
 
   .. image:: {{ article.image }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ from sphinx.application import Sphinx
 # -- Project information -----------------------------------------------------
 
 project = "Python Belgrade"
-copyright = "2024, Python Belgrade"
+copyright = "2026, Python Belgrade"
 author = "Python Belgrade"
 
 
@@ -69,9 +69,13 @@ with open("json-data/meetups.json") as file:
 with open("json-data/speakers.json") as file:
     speakers = json.load(file)
 
+with open("json-data/articles.json") as file:
+    articles = json.load(file)
+
 html_context = {
     "meetups": meetups,
     "speakers": speakers,
+    "articles": articles,
 }
 
 if os.environ.get("READTHEDOCS", "") == "True":
@@ -97,6 +101,10 @@ html_theme_options = {
         {
             "title": "Sponsorship",
             "url": "sponsorship/index",
+        },
+        {
+            "title": "Articles",
+            "url": "articles/index",
         },
         {
             "title": "Social",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,6 +74,7 @@ Only reason why you may want to bring a laptop would be if you are planning to g
 
    meetups/index
    speakers/index
+   articles/index
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/json-data/articles.json
+++ b/docs/source/json-data/articles.json
@@ -1,16 +1,16 @@
 {
-    "2026": [
-	{
-	    "id": 1,
-	    "title": "Writing agentic systems in Python",
-	    "description": "From Python as a non-negotiable foundation all the way to an entire agentic system, this straightforward guide charts out a roadmap for getting hands on experience as an AI first Python engineer.",
-	    "url": "https://dev.to/klement_gunndu/the-ai-engineering-stack-in-2026-what-to-learn-first-1nhj",
-	    "image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fimages.unsplash.com%2Fphoto-1709547228697-fa1f424a3f39%3Fcrop%3Dentropy%26cs%3Dtinysrgb%26fit%3Dmax%26fm%3Djpg%26ixid%3DM3w4ODA4ODZ8MHwxfHNlYXJjaHwxfHxwcm9ncmFtbWluZyUyMGNhcmVlciUyMGxlYXJuaW5nfGVufDB8MHx8fDE3NzM0OTE1Nzh8MA%26ixlib%3Drb-4.1.0%26q%3D80%26w%3D1080",
-	    "author": "Klement Gunndu",
-	    "authorUrl": "https://www.linkedin.com/in/klement-gunndu-601872351/"
+	"2026": [
+		{
+			"id": 1,
+			"title": "Writing agentic systems in Python",
+			"description": "From Python as a non-negotiable foundation all the way to an entire agentic system, this straightforward guide charts out a roadmap for getting hands on experience as an AI first Python engineer.",
+			"url": "https://dev.to/klement_gunndu/the-ai-engineering-stack-in-2026-what-to-learn-first-1nhj",
+			"image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fimages.unsplash.com%2Fphoto-1709547228697-fa1f424a3f39%3Fcrop%3Dentropy%26cs%3Dtinysrgb%26fit%3Dmax%26fm%3Djpg%26ixid%3DM3w4ODA4ODZ8MHwxfHNlYXJjaHwxfHxwcm9ncmFtbWluZyUyMGNhcmVlciUyMGxlYXJuaW5nfGVufDB8MHx8fDE3NzM0OTE1Nzh8MA%26ixlib%3Drb-4.1.0%26q%3D80%26w%3D1080",
+			"author": "Klement Gunndu",
+			"authorUrl": "https://www.linkedin.com/in/klement-gunndu-601872351/"
+		}
+	],
+	"archives": {
+		"2026": []
 	}
-    ],
-    "archives": {
-	"2026": []
-    }
 }

--- a/docs/source/json-data/articles.json
+++ b/docs/source/json-data/articles.json
@@ -1,0 +1,16 @@
+{
+    "2026": [
+	{
+	    "id": 1,
+	    "title": "Writing agentic systems in Python",
+	    "description": "From Python as a non-negotiable foundation all the way to an entire agentic system, this straightforward guide charts out a roadmap for getting hands on experience as an AI first Python engineer.",
+	    "url": "https://dev.to/klement_gunndu/the-ai-engineering-stack-in-2026-what-to-learn-first-1nhj",
+	    "image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fimages.unsplash.com%2Fphoto-1709547228697-fa1f424a3f39%3Fcrop%3Dentropy%26cs%3Dtinysrgb%26fit%3Dmax%26fm%3Djpg%26ixid%3DM3w4ODA4ODZ8MHwxfHNlYXJjaHwxfHxwcm9ncmFtbWluZyUyMGNhcmVlciUyMGxlYXJuaW5nfGVufDB8MHx8fDE3NzM0OTE1Nzh8MA%26ixlib%3Drb-4.1.0%26q%3D80%26w%3D1080",
+	    "author": "Klement Gunndu",
+	    "authorUrl": "https://www.linkedin.com/in/klement-gunndu-601872351/"
+	}
+    ],
+    "archives": {
+	"2026": []
+    }
+}

--- a/docs/source/json-data/articles.json
+++ b/docs/source/json-data/articles.json
@@ -1,16 +1,16 @@
 {
-	"2026": [
-		{
-			"id": 1,
-			"title": "Writing agentic systems in Python",
-			"description": "From Python as a non-negotiable foundation all the way to an entire agentic system, this straightforward guide charts out a roadmap for getting hands on experience as an AI first Python engineer.",
-			"url": "https://dev.to/klement_gunndu/the-ai-engineering-stack-in-2026-what-to-learn-first-1nhj",
-			"image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fimages.unsplash.com%2Fphoto-1709547228697-fa1f424a3f39%3Fcrop%3Dentropy%26cs%3Dtinysrgb%26fit%3Dmax%26fm%3Djpg%26ixid%3DM3w4ODA4ODZ8MHwxfHNlYXJjaHwxfHxwcm9ncmFtbWluZyUyMGNhcmVlciUyMGxlYXJuaW5nfGVufDB8MHx8fDE3NzM0OTE1Nzh8MA%26ixlib%3Drb-4.1.0%26q%3D80%26w%3D1080",
-			"author": "Klement Gunndu",
-			"authorUrl": "https://www.linkedin.com/in/klement-gunndu-601872351/"
-		}
-	],
-	"archives": {
-		"2026": []
-	}
+  "2026": [
+    {
+      "id": 1,
+      "title": "Writing agentic systems in Python",
+      "description": "From Python as a non-negotiable foundation all the way to an entire agentic system, this straightforward guide charts out a roadmap for getting hands on experience as an AI first Python engineer.",
+      "url": "https://dev.to/klement_gunndu/the-ai-engineering-stack-in-2026-what-to-learn-first-1nhj",
+      "image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fimages.unsplash.com%2Fphoto-1709547228697-fa1f424a3f39%3Fcrop%3Dentropy%26cs%3Dtinysrgb%26fit%3Dmax%26fm%3Djpg%26ixid%3DM3w4ODA4ODZ8MHwxfHNlYXJjaHwxfHxwcm9ncmFtbWluZyUyMGNhcmVlciUyMGxlYXJuaW5nfGVufDB8MHx8fDE3NzM0OTE1Nzh8MA%26ixlib%3Drb-4.1.0%26q%3D80%26w%3D1080",
+      "author": "Klement Gunndu",
+      "authorUrl": "https://www.linkedin.com/in/klement-gunndu-601872351/"
+    }
+  ],
+  "archives": {
+    "2026": []
+  }
 }


### PR DESCRIPTION
I'm thinking every year we can move articles into an archive for that year and keep the pythonbelgrade.com/articles page focused on the articles within that year.

That way we don't give ourselves a headache trying to maintain a lengthy linear list in Sphinx :)